### PR TITLE
fix: Archived officers permissions

### DIFF
--- a/src/functions/officer.ts
+++ b/src/functions/officer.ts
@@ -59,6 +59,11 @@ export async function getOfficerById(
 	});
 
 	if (!res.ok) {
+		// If officer not found in officers collection and we haven't checked archived yet,
+		// try checking the archived collection
+		if (res.status === 404 && !archived) {
+			return getOfficerById(officerId, true);
+		}
 		console.error(res.statusText);
 		return null;
 	}


### PR DESCRIPTION
There was a very terrible bug that when archived, you couldn't do anything in the database...